### PR TITLE
Swift 3 migration

### DIFF
--- a/Classes/ScrollableGraphView.swift
+++ b/Classes/ScrollableGraphView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 // MARK: - ScrollableGraphView
 @IBDesignable
-@objc public class ScrollableGraphView: UIScrollView, UIScrollViewDelegate, ScrollableGraphViewDrawingDelegate {
+@objc open class ScrollableGraphView: UIScrollView, UIScrollViewDelegate, ScrollableGraphViewDrawingDelegate {
     
     // MARK: - Public Properties
     // Use these to customise the graph.
@@ -12,10 +12,10 @@ import UIKit
     // ###########
     
     /// Specifies how thick the graph of the line is. In points.
-    @IBInspectable public var lineWidth: CGFloat = 2
+    @IBInspectable open var lineWidth: CGFloat = 2
     /// The color of the graph line. UIColor.
     // We must not use type inferring here or else the property won't show up in IB
-    @IBInspectable public var lineColor: UIColor = UIColor.blackColor()
+    @IBInspectable open var lineColor: UIColor = UIColor.black
     
     @IBInspectable var lineStyle_: Int {
         get { return lineStyle.rawValue }
@@ -26,35 +26,35 @@ import UIKit
         }
     }
     /// Whether or not the line should be rendered using bezier curves are straight lines.
-    public var lineStyle = ScrollableGraphViewLineStyle.Straight
+    open var lineStyle = ScrollableGraphViewLineStyle.straight
     /// How each segment in the line should connect. Takes any of the Core Animation LineJoin values.
-    @IBInspectable public var lineJoin: String = kCALineJoinRound
+    @IBInspectable open var lineJoin: String = kCALineJoinRound
     /// The line caps. Takes any of the Core Animation LineCap values.
-    @IBInspectable public var lineCap: String = kCALineCapRound
-    @IBInspectable public var lineCurviness: CGFloat = 0.5
+    @IBInspectable open var lineCap: String = kCALineCapRound
+    @IBInspectable open var lineCurviness: CGFloat = 0.5
     
     // Bar styles
     // ##########
     
     /// Whether bars should be drawn or not. If you want a bar graph, this should be set to true.
-    @IBInspectable public var shouldDrawBarLayer: Bool = false
+    @IBInspectable open var shouldDrawBarLayer: Bool = false
     /// The width of an individual bar on the graph.
-    @IBInspectable public var barWidth: CGFloat = 25;
+    @IBInspectable open var barWidth: CGFloat = 25;
     /// The actual colour of the bar.
-    @IBInspectable public var barColor: UIColor = UIColor.grayColor()
+    @IBInspectable open var barColor: UIColor = UIColor.gray
     /// The width of the outline of the bar
-    @IBInspectable public var barLineWidth: CGFloat = 1
+    @IBInspectable open var barLineWidth: CGFloat = 1
     /// The colour of the bar outline
-    @IBInspectable public var barLineColor: UIColor = UIColor.darkGrayColor()
+    @IBInspectable open var barLineColor: UIColor = UIColor.darkGray
     
     // Fill Styles
     // ###########
     
     /// The background colour for the entire graph view, not just the plotted graph.
-    @IBInspectable public var backgroundFillColor: UIColor = UIColor.whiteColor()
+    @IBInspectable open var backgroundFillColor: UIColor = UIColor.white
     
     /// Specifies whether or not the plotted graph should be filled with a colour or gradient.
-    @IBInspectable public var shouldFill: Bool = false
+    @IBInspectable open var shouldFill: Bool = false
     
     @IBInspectable var fillType_: Int {
         get { return fillType.rawValue }
@@ -65,13 +65,13 @@ import UIKit
         }
     }
     /// Specifies whether to fill the graph with a solid colour or gradient.
-    public var fillType = ScrollableGraphViewFillType.Solid
+    open var fillType = ScrollableGraphViewFillType.solid
     /// If fillType is set to .Solid then this colour will be used to fill the graph.
-    @IBInspectable public var fillColor: UIColor = UIColor.blackColor()
+    @IBInspectable open var fillColor: UIColor = UIColor.black
     /// If fillType is set to .Gradient then this will be the starting colour for the gradient.
-    @IBInspectable public var fillGradientStartColor: UIColor = UIColor.whiteColor()
+    @IBInspectable open var fillGradientStartColor: UIColor = UIColor.white
     /// If fillType is set to .Gradient, then this will be the ending colour for the gradient.
-    @IBInspectable public var fillGradientEndColor: UIColor = UIColor.blackColor()
+    @IBInspectable open var fillGradientEndColor: UIColor = UIColor.black
     
     @IBInspectable var fillGradientType_: Int {
         get { return fillGradientType.rawValue }
@@ -82,21 +82,21 @@ import UIKit
         }
     }
     /// If fillType is set to .Gradient, then this defines whether the gradient is rendered as a linear gradient or radial gradient.
-    public var fillGradientType = ScrollableGraphViewGradientType.Linear
+    open var fillGradientType = ScrollableGraphViewGradientType.linear
     
     // Spacing
     // #######
     
     /// How far the "maximum" reference line is from the top of the view's frame. In points.
-    @IBInspectable public var topMargin: CGFloat = 10
+    @IBInspectable open var topMargin: CGFloat = 10
     /// How far the "minimum" reference line is from the bottom of the view's frame. In points.
-    @IBInspectable public var bottomMargin: CGFloat = 10
+    @IBInspectable open var bottomMargin: CGFloat = 10
     /// How far the first point on the graph should be placed from the left hand side of the view.
-    @IBInspectable public var leftmostPointPadding: CGFloat = 50
+    @IBInspectable open var leftmostPointPadding: CGFloat = 50
     /// How far the final point on the graph should be placed from the right hand side of the view.
-    @IBInspectable public var rightmostPointPadding: CGFloat = 50
+    @IBInspectable open var rightmostPointPadding: CGFloat = 50
     /// How much space should be between each data point.
-    @IBInspectable public var dataPointSpacing: CGFloat = 40
+    @IBInspectable open var dataPointSpacing: CGFloat = 40
     
     @IBInspectable var direction_: Int {
         get { return direction.rawValue }
@@ -107,43 +107,43 @@ import UIKit
         }
     }
     /// Which side of the graph the user is expected to scroll from.
-    public var direction = ScrollableGraphViewDirection.LeftToRight
+    open var direction = ScrollableGraphViewDirection.leftToRight
     
     // Graph Range
     // ###########
     
     /// If this is set to true, then the range will automatically be detected from the data the graph is given.
-    @IBInspectable public var shouldAutomaticallyDetectRange: Bool = false
+    @IBInspectable open var shouldAutomaticallyDetectRange: Bool = false
     /// Forces the graph's minimum to always be zero. Used in conjunction with shouldAutomaticallyDetectRange or shouldAdaptRange, if you want to force the minimum to stay at 0 rather than the detected minimum.
-    @IBInspectable public var shouldRangeAlwaysStartAtZero: Bool = false // Used in conjunction with shouldAutomaticallyDetectRange, if you want to force the min to stay at 0.
+    @IBInspectable open var shouldRangeAlwaysStartAtZero: Bool = false // Used in conjunction with shouldAutomaticallyDetectRange, if you want to force the min to stay at 0.
     /// The minimum value for the y-axis. This is ignored when shouldAutomaticallyDetectRange or shouldAdaptRange = true
-    @IBInspectable public var rangeMin: Double = 0
+    @IBInspectable open var rangeMin: Double = 0
     /// The maximum value for the y-axis. This is ignored when shouldAutomaticallyDetectRange or shouldAdaptRange = true
-    @IBInspectable public var rangeMax: Double = 100
+    @IBInspectable open var rangeMax: Double = 100
     
     // Data Point Drawing
     // ##################
     
     /// Whether or not to draw a symbol for each data point.
-    @IBInspectable public var shouldDrawDataPoint: Bool = true
+    @IBInspectable open var shouldDrawDataPoint: Bool = true
     /// The shape to draw for each data point.
-    public var dataPointType = ScrollableGraphViewDataPointType.Circle
+    open var dataPointType = ScrollableGraphViewDataPointType.circle
     /// The size of the shape to draw for each data point.
-    @IBInspectable public var dataPointSize: CGFloat = 5
+    @IBInspectable open var dataPointSize: CGFloat = 5
     /// The colour with which to fill the shape.
-    @IBInspectable public var dataPointFillColor: UIColor = UIColor.blackColor()
+    @IBInspectable open var dataPointFillColor: UIColor = UIColor.black
     /// If dataPointType is set to .Custom then you,can provide a closure to create any kind of shape you would like to be displayed instead of just a circle or square. The closure takes a CGPoint which is the centre of the shape and it should return a complete UIBezierPath.
-    public var customDataPointPath: ((centre: CGPoint) -> UIBezierPath)?
+    open var customDataPointPath: ((_ centre: CGPoint) -> UIBezierPath)?
     
     // Adapting & Animations
     // #####################
     
     /// Whether or not the y-axis' range should adapt to the points that are visible on screen. This means if there are only 5 points visible on screen at any given time, the maximum on the y-axis will be the maximum of those 5 points. This is updated automatically as the user scrolls along the graph.
-    @IBInspectable public var shouldAdaptRange: Bool = false
+    @IBInspectable open var shouldAdaptRange: Bool = false
     /// If shouldAdaptRange is set to true then this specifies whether or not the points on the graph should animate to their new positions. Default is set to true.
-    @IBInspectable public var shouldAnimateOnAdapt: Bool = true
+    @IBInspectable open var shouldAnimateOnAdapt: Bool = true
     /// How long the animation should take. Affects both the startup animation and the animation when the range of the y-axis adapts to onscreen points.
-    @IBInspectable public var animationDuration: Double = 1
+    @IBInspectable open var animationDuration: Double = 1
     
     @IBInspectable var adaptAnimationType_: Int {
         get { return adaptAnimationType.rawValue }
@@ -154,21 +154,21 @@ import UIKit
         }
     }
     /// The animation style.
-    public var adaptAnimationType = ScrollableGraphViewAnimationType.EaseOut
+    open var adaptAnimationType = ScrollableGraphViewAnimationType.easeOut
     /// If adaptAnimationType is set to .Custom, then this is the easing function you would like applied for the animation.
-    public var customAnimationEasingFunction: ((t: Double) -> Double)?
+    open var customAnimationEasingFunction: ((_ t: Double) -> Double)?
     /// Whether or not the graph should animate to their positions when the graph is first displayed.
-    @IBInspectable public var shouldAnimateOnStartup: Bool = true
+    @IBInspectable open var shouldAnimateOnStartup: Bool = true
     
     // Reference Lines
     // ###############
     
     /// Whether or not to show the y-axis reference lines and labels.
-    @IBInspectable public var shouldShowReferenceLines: Bool = true
+    @IBInspectable open var shouldShowReferenceLines: Bool = true
     /// The colour for the reference lines.
-    @IBInspectable public var referenceLineColor: UIColor = UIColor.blackColor()
+    @IBInspectable open var referenceLineColor: UIColor = UIColor.black
     /// The thickness of the reference lines.
-    @IBInspectable public var referenceLineThickness: CGFloat = 0.5
+    @IBInspectable open var referenceLineThickness: CGFloat = 0.5
     
     @IBInspectable var referenceLinePosition_: Int {
         get { return referenceLinePosition.rawValue }
@@ -179,49 +179,49 @@ import UIKit
         }
     }
     /// Where the labels should be displayed on the reference lines.
-    public var referenceLinePosition = ScrollableGraphViewReferenceLinePosition.Left
+    open var referenceLinePosition = ScrollableGraphViewReferenceLinePosition.left
     /// The type of reference lines. Currently only .Cover is available.
-    public var referenceLineType = ScrollableGraphViewReferenceLineType.Cover
+    open var referenceLineType = ScrollableGraphViewReferenceLineType.cover
     
     /// How many reference lines should be between the minimum and maximum reference lines. If you want a total of 4 reference lines, you would set this to 2. This can be set to 0 for no intermediate reference lines.This can be used to create reference lines at specific intervals. If the desired result is to have a reference line at every 10 units on the y-axis, you could, for example, set rangeMax to 100, rangeMin to 0 and numberOfIntermediateReferenceLines to 9.
-    @IBInspectable public var numberOfIntermediateReferenceLines: Int = 3
+    @IBInspectable open var numberOfIntermediateReferenceLines: Int = 3
     /// Whether or not to add labels to the intermediate reference lines.
-    @IBInspectable public var shouldAddLabelsToIntermediateReferenceLines: Bool = true
+    @IBInspectable open var shouldAddLabelsToIntermediateReferenceLines: Bool = true
     /// Whether or not to add units specified by the referenceLineUnits variable to the labels on the intermediate reference lines.
-    @IBInspectable public var shouldAddUnitsToIntermediateReferenceLineLabels: Bool = false
+    @IBInspectable open var shouldAddUnitsToIntermediateReferenceLineLabels: Bool = false
     
     // Reference Line Labels
     // #####################
     
     /// The font to be used for the reference line labels.
-    public var referenceLineLabelFont = UIFont.systemFontOfSize(8)
+    open var referenceLineLabelFont = UIFont.systemFont(ofSize: 8)
     /// The colour of the reference line labels.
-    @IBInspectable public var referenceLineLabelColor: UIColor = UIColor.blackColor()
+    @IBInspectable open var referenceLineLabelColor: UIColor = UIColor.black
     
     /// Whether or not to show the units on the reference lines.
-    @IBInspectable public var shouldShowReferenceLineUnits: Bool = true
+    @IBInspectable open var shouldShowReferenceLineUnits: Bool = true
     /// The units that the y-axis is in. This string is used for labels on the reference lines.
-    @IBInspectable public var referenceLineUnits: String?
+    @IBInspectable open var referenceLineUnits: String?
     /// The number of decimal places that should be shown on the reference line labels.
-    @IBInspectable public var referenceLineNumberOfDecimalPlaces: Int = 0
+    @IBInspectable open var referenceLineNumberOfDecimalPlaces: Int = 0
     /// The NSNumberFormatterStyle that reference lines should use to display
-    @IBInspectable public var referenceLineNumberStyle: NSNumberFormatterStyle = .NoStyle
+    @IBInspectable open var referenceLineNumberStyle: NumberFormatter.Style = .none
     
     // Data Point Labels
     // #################
     
     /// Whether or not to show the labels on the x-axis for each point.
-    @IBInspectable public var shouldShowLabels: Bool = true
+    @IBInspectable open var shouldShowLabels: Bool = true
     /// How far from the "minimum" reference line the data point labels should be rendered.
-    @IBInspectable public var dataPointLabelTopMargin: CGFloat = 10
+    @IBInspectable open var dataPointLabelTopMargin: CGFloat = 10
     /// How far from the bottom of the view the data point labels should be rendered.
-    @IBInspectable public var dataPointLabelBottomMargin: CGFloat = 0
+    @IBInspectable open var dataPointLabelBottomMargin: CGFloat = 0
     /// The font for the data point labels.
-    @IBInspectable public var dataPointLabelColor: UIColor = UIColor.blackColor()
+    @IBInspectable open var dataPointLabelColor: UIColor = UIColor.black
     /// The colour for the data point labels.
-    public var dataPointLabelFont: UIFont? = UIFont.systemFontOfSize(10)
+    open var dataPointLabelFont: UIFont? = UIFont.systemFont(ofSize: 10)
     /// Used to force the graph to show every n-th dataPoint label
-    @IBInspectable public var dataPointLabelsSparsity: Int = 1
+    @IBInspectable open var dataPointLabelsSparsity: Int = 1
   
     // MARK: - Private State
     // #####################
@@ -274,10 +274,10 @@ import UIKit
     
     // Active Points & Range Calculation
     
-    private var previousActivePointsInterval: Range<Int> = -1 ..< -1
-    private var activePointsInterval: Range<Int> = -1 ..< -1 {
+    private var previousActivePointsInterval: CountableRange<Int> = -1 ..< -1
+    private var activePointsInterval: CountableRange<Int> = -1 ..< -1 {
         didSet {
-            if(oldValue.startIndex != activePointsInterval.startIndex || oldValue.endIndex != activePointsInterval.endIndex) {
+            if(oldValue.lowerBound != activePointsInterval.lowerBound || oldValue.upperBound != activePointsInterval.upperBound) {
                 if !isCurrentlySettingUp { activePointsDidChange() }
             }
         }
@@ -306,10 +306,10 @@ import UIKit
         displayLink?.invalidate()
     }
     
-    public override func prepareForInterfaceBuilder() {
+    open override func prepareForInterfaceBuilder() {
         super.prepareForInterfaceBuilder()
         
-        setData([10, 2, 34, 11, 22, 11, 44, 9, 12, 4], withLabels: ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"])
+        set(data: [10, 2, 34, 11, 22, 11, 44, 9, 12, 4], withLabels: ["One", "Two", "Three", "Four", "Five", "Six", "Seven", "Eight", "Nine", "Ten"])
     }
     
     private func setup() {
@@ -325,14 +325,14 @@ import UIKit
         self.viewportWidth = self.frame.width
         self.viewportHeight = self.frame.height
         
-        totalGraphWidth = graphWidthForNumberOfDataPoints(data.count)
+        totalGraphWidth = graphWidth(forNumberOfDataPoints: data.count)
         self.contentSize = CGSize(width: totalGraphWidth, height: viewportHeight)
         
         // Scrolling direction.
         #if TARGET_INTERFACE_BUILDER
             self.offsetWidth = 0
         #else
-        if (direction == .RightToLeft) {
+        if (direction == .rightToLeft) {
             self.offsetWidth = self.contentSize.width - viewportWidth
         }
             // Otherwise start of all the way to the left.
@@ -346,7 +346,7 @@ import UIKit
         
         // Calculate the initial range depending on settings.
         let initialActivePointsInterval = calculateActivePointsInterval()
-        let detectedRange = calculateRangeForEntireDataset(self.data)
+        let detectedRange = calculateRange(forEntireDataset: self.data)
         
         if(shouldAutomaticallyDetectRange) {
             self.range = detectedRange
@@ -356,7 +356,7 @@ import UIKit
         }
         
         if (shouldAdaptRange) { // This supercedes the shouldAutomaticallyDetectRange option
-            let range = calculateRangeForActivePointsInterval(initialActivePointsInterval)
+            let range = calculateRange(forActivePointsInterval: initialActivePointsInterval)
             self.range = range
         }
         
@@ -377,7 +377,7 @@ import UIKit
             let value = (shouldAnimateOnStartup) ? self.range.min : data[i]
             #endif
             
-            let position = calculatePosition(i, value: value)
+            let position = calculatePosition(atIndex: i, value: value)
             let point = GraphPoint(position: position)
             graphPoints.append(point)
         }
@@ -402,8 +402,8 @@ import UIKit
         #if !TARGET_INTERFACE_BUILDER
         // Animation loop for when the range adapts
         displayLink = CADisplayLink(target: self, selector: #selector(animationUpdate))
-        displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
-        displayLink.paused = true
+        displayLink.add(to: RunLoop.main, forMode: RunLoopMode.commonModes)
+        displayLink.isPaused = true
         #endif
         
         isCurrentlySettingUp = false
@@ -452,7 +452,7 @@ import UIKit
         // Gradient and Fills
         switch (self.fillType) {
             
-        case .Solid:
+        case .solid:
             if(shouldFill) {
                 // Setup fill
                 fillLayer = FillDrawingLayer(frame: viewport, fillColor: fillColor)
@@ -460,7 +460,7 @@ import UIKit
                 drawingView.layer.insertSublayer(fillLayer!, below: lineLayer)
             }
             
-        case .Gradient:
+        case .gradient:
             if(shouldFill) {
                 gradientLayer = GradientDrawingLayer(frame: viewport, startColor: fillGradientStartColor, endColor: fillGradientEndColor, gradientType: fillGradientType)
                 gradientLayer!.graphViewDrawingDelegate = self
@@ -510,12 +510,12 @@ import UIKit
         referenceLineView?.labelDecimalPlaces = self.referenceLineNumberOfDecimalPlaces
         referenceLineView?.labelNumberStyle = self.referenceLineNumberStyle
         
-        referenceLineView?.setRange(self.range)
+        referenceLineView?.set(range: self.range)
         self.addSubview(referenceLineView!)
     }
     
     // If the view has changed we have to make sure we're still displaying the right data.
-    override public func layoutSubviews() {
+    override open func layoutSubviews() {
         super.layoutSubviews()
         
         // while putting the view on the IB, we may get calls with frame too small
@@ -571,7 +571,7 @@ import UIKit
             
             // If adaption is enabled we want to
             if(shouldAdaptRange) {
-                let newRange = calculateRangeForActivePointsInterval(newActivePointsInterval)
+                let newRange = calculateRange(forActivePointsInterval: newActivePointsInterval)
                 self.range = newRange
             }
         }
@@ -596,7 +596,7 @@ import UIKit
         gradientLayer?.frame.size.height = viewportHeight
         
         // Reference lines should extend over the entire viewport
-        referenceLineView?.setViewport(viewportWidth, viewportHeight: viewportHeight)
+        referenceLineView?.set(viewportWidth: viewportWidth, viewportHeight: viewportHeight)
         
         self.contentSize.height = viewportHeight
     }
@@ -604,7 +604,7 @@ import UIKit
     // MARK: - Public Methods
     // ######################
     
-    public func setData(data: [Double], withLabels labels: [String]) {
+    open func set(data: [Double], withLabels labels: [String]) {
         
         // If we are setting exactly the same data and labels, there's no need to re-init everything.
         if(self.data == data && self.labels == labels) {
@@ -631,32 +631,32 @@ import UIKit
         
         for animation in currentAnimations {
             
-            animation.update(dt)
+            animation.update(withTimestamp: dt)
             
             if animation.finished {
-                dequeueAnimation(animation)
+                dequeue(animation: animation)
             }
         }
         
         updatePaths()
     }
     
-    private func animatePoint(point: GraphPoint, toPosition position: CGPoint, withDelay delay: Double = 0) {
+    private func animate(point: GraphPoint, to position: CGPoint, withDelay delay: Double = 0) {
         let currentPoint = CGPoint(x: point.x, y: point.y)
         let animation = GraphPointAnimation(fromPoint: currentPoint, toPoint: position, forGraphPoint: point)
         animation.animationEasing = getAnimationEasing()
         animation.duration = animationDuration
         animation.delay = delay
-        enqueueAnimation(animation)
+        enqueue(animation: animation)
     }
     
     private func getAnimationEasing() -> (Double) -> Double {
         switch(self.adaptAnimationType) {
-        case .Elastic:
-            return Easings.EaseOutElastic
-        case .EaseOut:
-            return Easings.EaseOutQuad
-        case .Custom:
+        case .elastic:
+            return Easings.easeOutElastic
+        case .easeOut:
+            return Easings.easeOutQuad
+        case .custom:
             if let customEasing = customAnimationEasingFunction {
                 return customEasing
             }
@@ -664,26 +664,26 @@ import UIKit
                 fallthrough
             }
         default:
-            return Easings.EaseOutQuad
+            return Easings.easeOutQuad
         }
     }
     
-    private func enqueueAnimation(animation: GraphPointAnimation) {
+    private func enqueue(animation: GraphPointAnimation) {
         if (currentAnimations.count == 0) {
             // Need to kick off the loop.
-            displayLink.paused = false
+            displayLink.isPaused = false
         }
         currentAnimations.append(animation)
     }
     
-    private func dequeueAnimation(animation: GraphPointAnimation) {
-        if let index = currentAnimations.indexOf(animation) {
-            currentAnimations.removeAtIndex(index)
+    private func dequeue(animation: GraphPointAnimation) {
+        if let index = currentAnimations.index(of: animation) {
+            currentAnimations.remove(at: index)
         }
         
         if(currentAnimations.count == 0) {
             // Stop animation loop.
-            displayLink.paused = true
+            displayLink.isPaused = true
         }
     }
     
@@ -694,7 +694,7 @@ import UIKit
         }
         
         currentAnimations.removeAll()
-        displayLink.paused = true
+        displayLink.isPaused = true
     }
     
     private func timeSinceLastFrame() -> Double {
@@ -717,7 +717,7 @@ import UIKit
     
     // MARK: Layout Calculations
     
-    private func calculateActivePointsInterval() -> Range<Int> {
+    private func calculateActivePointsInterval() -> CountableRange<Int> {
         
         // Calculate the "active points"
         let min = Int((offsetWidth) / dataPointSpacing)
@@ -729,13 +729,13 @@ import UIKit
         
         let numberOfPointsOffscreen = 2
         
-        let actualMin = clamp(min - numberOfPointsOffscreen, min: minPossible, max: maxPossible)
-        let actualMax = clamp(max + numberOfPointsOffscreen, min: minPossible, max: maxPossible)
+        let actualMin = clamp(value: min - numberOfPointsOffscreen, min: minPossible, max: maxPossible)
+        let actualMax = clamp(value: max + numberOfPointsOffscreen, min: minPossible, max: maxPossible)
         
-        return actualMin ... actualMax
+        return actualMin..<actualMax.advanced(by: 1)
     }
     
-    private func calculateRangeForActivePointsInterval(interval: Range<Int>) -> (min: Double, max: Double) {
+    private func calculateRange(forActivePointsInterval interval: CountableRange<Int>) -> (min: Double, max: Double) {
         
         let dataForActivePoints = data[interval]
         
@@ -745,17 +745,17 @@ import UIKit
         }
         else {
             
-            let range = calculateRange(dataForActivePoints)
-            return cleanRange(range)
+            let range = calculateRange(for: dataForActivePoints)
+            return clean(range: range)
         }
     }
     
-    private func calculateRangeForEntireDataset(data: [Double]) -> (min: Double, max: Double) {
-        let range = calculateRange(self.data)
-        return cleanRange(range)
+    private func calculateRange(forEntireDataset data: [Double]) -> (min: Double, max: Double) {
+        let range = calculateRange(for: self.data)
+        return clean(range: range)
     }
     
-    private func calculateRange<T: CollectionType where T.Generator.Element == Double>(data: T) -> (min: Double, max: Double) {
+    private func calculateRange<T: Collection>(for data: T) -> (min: Double, max: Double) where T.Iterator.Element == Double {
         
         var rangeMin: Double = Double(Int.max)
         var rangeMax: Double = Double(Int.min)
@@ -772,7 +772,7 @@ import UIKit
         return (min: rangeMin, max: rangeMax)
     }
     
-    private func cleanRange(range: (min: Double, max: Double)) -> (min: Double, max: Double){
+    private func clean(range: (min: Double, max: Double)) -> (min: Double, max: Double){
         if(range.min == range.max) {
             
             let min = shouldRangeAlwaysStartAtZero ? 0 : range.min
@@ -797,12 +797,12 @@ import UIKit
         }
     }
     
-    private func graphWidthForNumberOfDataPoints(numberOfPoints: Int) -> CGFloat {
+    private func graphWidth(forNumberOfDataPoints numberOfPoints: Int) -> CGFloat {
         let width: CGFloat = (CGFloat(numberOfPoints - 1) * dataPointSpacing) + (leftmostPointPadding + rightmostPointPadding)
         return width
     }
     
-    private func calculatePosition(index: Int, value: Double) -> CGPoint {
+    private func calculatePosition(atIndex index: Int, value: Double) -> CGPoint {
         
         // Set range defaults based on settings:
         
@@ -841,65 +841,65 @@ import UIKit
     }
     
     // MARK: Line Path Creation
-    
+    @discardableResult
     private func createLinePath() -> UIBezierPath {
         
         currentLinePath.removeAllPoints()
         
-        let pathSegmentAdder = lineStyle == .Straight ? addStraightLineSegment : addCurvedLineSegment
+        let pathSegmentAdder = lineStyle == .straight ? addStraightLineSegment : addCurvedLineSegment
         
-        zeroYPosition = calculatePosition(0, value: self.range.min).y
+        zeroYPosition = calculatePosition(atIndex: 0, value: self.range.min).y
         
         // Connect the line to the starting edge if we are filling it.
         if(shouldFill) {
             // Add a line from the base of the graph to the first data point.
-            let firstDataPoint = graphPoints[activePointsInterval.startIndex]
+            let firstDataPoint = graphPoints[activePointsInterval.lowerBound]
             
             let viewportLeftZero = CGPoint(x: firstDataPoint.x - (leftmostPointPadding), y: zeroYPosition)
             let leftFarEdgeTop = CGPoint(x: firstDataPoint.x - (leftmostPointPadding + viewportWidth), y: zeroYPosition)
             let leftFarEdgeBottom = CGPoint(x: firstDataPoint.x - (leftmostPointPadding + viewportWidth), y: viewportHeight)
             
-            currentLinePath.moveToPoint(leftFarEdgeBottom)
-            pathSegmentAdder(startPoint: leftFarEdgeBottom, endPoint: leftFarEdgeTop, inPath: currentLinePath)
-            pathSegmentAdder(startPoint: leftFarEdgeTop, endPoint: viewportLeftZero, inPath: currentLinePath)
-            pathSegmentAdder(startPoint: viewportLeftZero, endPoint: CGPoint(x: firstDataPoint.x, y: firstDataPoint.y), inPath: currentLinePath)
+            currentLinePath.move(to: leftFarEdgeBottom)
+            pathSegmentAdder(leftFarEdgeBottom, leftFarEdgeTop, currentLinePath)
+            pathSegmentAdder(leftFarEdgeTop, viewportLeftZero, currentLinePath)
+            pathSegmentAdder(viewportLeftZero, CGPoint(x: firstDataPoint.x, y: firstDataPoint.y), currentLinePath)
         }
         else {
-            let firstDataPoint = graphPoints[activePointsInterval.startIndex]
-            currentLinePath.moveToPoint(firstDataPoint.location)
+            let firstDataPoint = graphPoints[activePointsInterval.lowerBound]
+            currentLinePath.move(to: firstDataPoint.location)
         }
         
         // Connect each point on the graph with a segment.
-        for i in activePointsInterval.startIndex ..< activePointsInterval.endIndex - 1 {
+        for i in activePointsInterval.lowerBound ..< activePointsInterval.upperBound - 1 {
             
             let startPoint = graphPoints[i].location
             let endPoint = graphPoints[i+1].location
             
-            pathSegmentAdder(startPoint: startPoint, endPoint: endPoint, inPath: currentLinePath)
+            pathSegmentAdder(startPoint, endPoint, currentLinePath)
         }
         
         // Connect the line to the ending edge if we are filling it.
         if(shouldFill) {
             // Add a line from the last data point to the base of the graph.
-            let lastDataPoint = graphPoints[activePointsInterval.endIndex - 1]
+            let lastDataPoint = graphPoints[activePointsInterval.upperBound - 1]
             
             let viewportRightZero = CGPoint(x: lastDataPoint.x + (rightmostPointPadding), y: zeroYPosition)
             let rightFarEdgeTop = CGPoint(x: lastDataPoint.x + (rightmostPointPadding + viewportWidth), y: zeroYPosition)
             let rightFarEdgeBottom = CGPoint(x: lastDataPoint.x + (rightmostPointPadding + viewportWidth), y: viewportHeight)
             
-            pathSegmentAdder(startPoint: lastDataPoint.location, endPoint: viewportRightZero, inPath: currentLinePath)
-            pathSegmentAdder(startPoint: viewportRightZero, endPoint: rightFarEdgeTop, inPath: currentLinePath)
-            pathSegmentAdder(startPoint: rightFarEdgeTop, endPoint: rightFarEdgeBottom, inPath: currentLinePath)
+            pathSegmentAdder(lastDataPoint.location, viewportRightZero, currentLinePath)
+            pathSegmentAdder(viewportRightZero, rightFarEdgeTop, currentLinePath)
+            pathSegmentAdder(rightFarEdgeTop, rightFarEdgeBottom, currentLinePath)
         }
         
         return currentLinePath
     }
     
-    private func addStraightLineSegment(startPoint startPoint: CGPoint, endPoint: CGPoint, inPath path: UIBezierPath) {
-        path.addLineToPoint(endPoint)
+    private func addStraightLineSegment(startPoint: CGPoint, endPoint: CGPoint, inPath path: UIBezierPath) {
+        path.addLine(to: endPoint)
     }
     
-    private func addCurvedLineSegment(startPoint startPoint: CGPoint, endPoint: CGPoint, inPath path: UIBezierPath) {
+    private func addCurvedLineSegment(startPoint: CGPoint, endPoint: CGPoint, inPath path: UIBezierPath) {
         // calculate control points
         let difference = endPoint.x - startPoint.x
         
@@ -912,7 +912,7 @@ import UIKit
         let controlPointTwo = CGPoint(x: x, y: y)
         
         // add curve from start to end
-        currentLinePath.addCurveToPoint(endPoint, controlPoint1: controlPointOne, controlPoint2: controlPointTwo)
+        currentLinePath.addCurve(to: endPoint, controlPoint1: controlPointOne, controlPoint2: controlPointTwo)
     }
     
     // MARK: Events
@@ -927,7 +927,7 @@ import UIKit
       if(shouldShowLabels) {
         let deactivatedLabelPoints = filterPointsForLabels(fromPoints: deactivatedPoints)
         let activatedLabelPoints = filterPointsForLabels(fromPoints: activatedPoints)
-        updateLabels(deactivatedLabelPoints, activatedLabelPoints)
+        updateLabels(deactivatedPoints: deactivatedLabelPoints, activatedPoints: activatedLabelPoints)
       }
   }
   
@@ -936,7 +936,7 @@ import UIKit
         // If shouldAnimateOnAdapt is enabled it will kickoff any animations that need to occur.
         startAnimations()
         
-        referenceLineView?.setRange(range)
+        referenceLineView?.set(range: range)
     }
     
     private func viewportDidChange() {
@@ -981,16 +981,16 @@ import UIKit
     }
     
     // Update any labels for any new points that have been activated and deactivated.
-    private func updateLabels(deactivatedPoints: [Int], _ activatedPoints: [Int]) {
+    private func updateLabels(deactivatedPoints: [Int], activatedPoints: [Int]) {
         
         // Disable any labels for the deactivated points.
         for point in deactivatedPoints {
-            labelPool.deactivateLabelForPointIndex(point)
+            labelPool.activateLabel(forPointIndex: point)
         }
         
         // Grab an unused label and update it to the right position for the newly activated poitns
         for point in activatedPoints {
-            let label = labelPool.activateLabelForPointIndex(point)
+            let label = labelPool.activateLabel(forPointIndex: point)
             
             label.text = (point < labels.count) ? labels[point] : ""
             label.textColor = dataPointLabelColor
@@ -1001,7 +1001,7 @@ import UIKit
             // self.range.min is the current ranges minimum that has been detected
             // self.rangeMin is the minimum that should be used as specified by the user
             let rangeMin = (shouldAutomaticallyDetectRange || shouldAdaptRange) ? self.range.min : self.rangeMin
-            let position = calculatePosition(point, value: rangeMin)
+            let position = calculatePosition(atIndex: point, value: rangeMin)
             
             label.frame = CGRect(origin: CGPoint(x: position.x - label.frame.width / 2, y: position.y + dataPointLabelTopMargin), size: label.frame.size)
             
@@ -1013,7 +1013,7 @@ import UIKit
         for label in labelPool.activeLabels {
             
             let rangeMin = (shouldAutomaticallyDetectRange || shouldAdaptRange) ? self.range.min : self.rangeMin
-            let position = calculatePosition(0, value: rangeMin)
+            let position = calculatePosition(atIndex: 0, value: rangeMin)
             
             label.frame.origin.y = position.y + dataPointLabelTopMargin
         }
@@ -1021,39 +1021,31 @@ import UIKit
     
     // Returns the indices of any points that became inactive (that is, "off screen"). (No order)
     private func determineDeactivatedPoints() -> [Int] {
-        let prevSet = setFromClosedRange(previousActivePointsInterval)
-        let currSet = setFromClosedRange(activePointsInterval)
+        let prevSet = Set(previousActivePointsInterval)
+        let currSet = Set(activePointsInterval)
         
-        let deactivatedPoints = prevSet.subtract(currSet)
+        let deactivatedPoints = prevSet.subtracting(currSet)
         
         return Array(deactivatedPoints)
     }
     
     // Returns the indices of any points that became active (on screen). (No order)
     private func determineActivatedPoints() -> [Int] {
-        let prevSet = setFromClosedRange(previousActivePointsInterval)
-        let currSet = setFromClosedRange(activePointsInterval)
+        let prevSet = Set(previousActivePointsInterval)
+        let currSet = Set(activePointsInterval)
         
-        let activatedPoints = currSet.subtract(prevSet)
+        let activatedPoints = currSet.subtracting(prevSet)
         
         return Array(activatedPoints)
     }
-    
-    private func setFromClosedRange(range: Range<Int>) -> Set<Int> {
-        var set = Set<Int>()
-        for index in range.startIndex...range.endIndex {
-            set.insert(index)
-        }
-        return set
-    }
   
-  private func filterPointsForLabels(fromPoints points:[Int]) -> [Int] {
-    
-    if(self.dataPointLabelsSparsity == 1) {
-      return points
+    private func filterPointsForLabels(fromPoints points:[Int]) -> [Int] {
+        
+        if(self.dataPointLabelsSparsity == 1) {
+            return points
+        }
+        return points.filter({ $0 % self.dataPointLabelsSparsity == 0 })
     }
-    return points.filter({ $0 % self.dataPointLabelsSparsity == 0 })
-  }
   
     private func startAnimations(withStaggerValue stagger: Double = 0) {
         
@@ -1069,41 +1061,42 @@ import UIKit
         //let numberOfPointsToAnimate = pointsToAnimate.endIndex - pointsToAnimate.startIndex
         var index = 0
         for i in pointsToAnimate {
-            let newPosition = calculatePosition(i, value: data[i])
+            let newPosition = calculatePosition(atIndex: i, value: data[i])
             let point = graphPoints[i]
-            animatePoint(point, toPosition: newPosition, withDelay: Double(index) * stagger)
+            animate(point: point, to: newPosition, withDelay: Double(index) * stagger)
             index += 1
         }
         
         // Update any non-visible & non-animating points so they come on to screen at the right scale.
         for i in 0 ..< graphPoints.count {
-            if(i > pointsToAnimate.startIndex && i < pointsToAnimate.endIndex || graphPoints[i].currentlyAnimatingToPosition) {
+            if(i > pointsToAnimate.lowerBound && i < pointsToAnimate.upperBound || graphPoints[i].currentlyAnimatingToPosition) {
                 continue
             }
             
-            let newPosition = calculatePosition(i, value: data[i])
+            let newPosition = calculatePosition(atIndex: i, value: data[i])
             graphPoints[i].x = newPosition.x
             graphPoints[i].y = newPosition.y
         }
     }
     
     // MARK: - Drawing Delegate
-    private func currentPath() -> UIBezierPath {
+    fileprivate func currentPath() -> UIBezierPath {
         return currentLinePath
     }
     
-    private func intervalForActivePoints() -> Range<Int> {
+    fileprivate func intervalForActivePoints() -> CountableRange<Int> {
         return activePointsInterval
     }
     
-    private func rangeForActivePoints() -> (min: Double, max: Double) {
+    fileprivate func rangeForActivePoints() -> (min: Double, max: Double) {
         return range
     }
     
-    private func graphPointForIndex(index: Int) -> GraphPoint {
+    fileprivate func graphPoint(forIndex index: Int) -> GraphPoint {
         return graphPoints[index]
     }
 }
+
 
 // MARK: - LabelPool
 private class LabelPool {
@@ -1112,7 +1105,7 @@ private class LabelPool {
     var relations = [Int : Int]()
     var unused = [Int]()
     
-    func deactivateLabelForPointIndex(pointIndex: Int){
+    func deactivateLabel(forPointIndex pointIndex: Int){
         
         if let unusedLabelIndex = relations[pointIndex] {
             unused.append(unusedLabelIndex)
@@ -1120,7 +1113,8 @@ private class LabelPool {
         relations[pointIndex] = nil
     }
     
-    func activateLabelForPointIndex(pointIndex: Int) -> UILabel {
+    @discardableResult
+    func activateLabel(forPointIndex pointIndex: Int) -> UILabel {
         var label: UILabel
         
         if(unused.count >= 1) {
@@ -1133,7 +1127,7 @@ private class LabelPool {
         else {
             label = UILabel()
             labels.append(label)
-            let newLabelIndex = labels.indexOf(label)!
+            let newLabelIndex = labels.index(of: label)!
             relations[pointIndex] = newLabelIndex
         }
         
@@ -1163,7 +1157,7 @@ private class GraphPoint {
     var location = CGPoint(x: 0, y: 0)
     var currentlyAnimatingToPosition = false
     
-    private var x: CGFloat {
+    fileprivate var x: CGFloat {
         get {
             return location.x
         }
@@ -1172,7 +1166,7 @@ private class GraphPoint {
         }
     }
     
-    private var y: CGFloat {
+    fileprivate var y: CGFloat {
         get {
             return location.y
         }
@@ -1181,7 +1175,7 @@ private class GraphPoint {
         }
     }
     
-    init(position: CGPoint = CGPointZero) {
+    init(position: CGPoint = CGPoint.zero) {
         x = position.x
         y = position.y
     }
@@ -1190,7 +1184,7 @@ private class GraphPoint {
 private class GraphPointAnimation : Equatable {
     
     // Public Properties
-    var animationEasing = Easings.EaseOutQuad
+    var animationEasing = Easings.easeOutQuad
     var duration: Double = 1
     var delay: Double = 0
     private(set) var finished = false
@@ -1216,7 +1210,7 @@ private class GraphPointAnimation : Equatable {
         GraphPointAnimation.animationsCreated += 1
     }
     
-    func update(dt: Double) {
+    func update(withTimestamp dt: Double) {
         
         if(!finished) {
             
@@ -1254,20 +1248,19 @@ private class GraphPointAnimation : Equatable {
         self.graphPoint?.currentlyAnimatingToPosition = false
         self.finished = true
     }
+    
+    static func ==(lhs: GraphPointAnimation, rhs: GraphPointAnimation) -> Bool {
+        return lhs.animationKey == rhs.animationKey
+    }
 }
-
-private func ==(lhs: GraphPointAnimation, rhs: GraphPointAnimation) -> Bool {
-    return lhs.animationKey == rhs.animationKey
-}
-
 
 // MARK: - Drawing Layers
 
 // MARK: Delegate definition that provides the data required by the drawing layers.
 private protocol ScrollableGraphViewDrawingDelegate {
-    func intervalForActivePoints() -> Range<Int>
+    func intervalForActivePoints() -> CountableRange<Int>
     func rangeForActivePoints() -> (min: Double, max: Double)
-    func graphPointForIndex(index: Int) -> GraphPoint
+    func graphPoint(forIndex index: Int) -> GraphPoint
     
     func currentPath() -> UIBezierPath
 }
@@ -1332,8 +1325,8 @@ private class BarDrawingLayer: ScrollableGraphViewDrawingLayer {
         
         self.barWidth = barWidth
         self.lineWidth = barLineWidth
-        self.strokeColor = barLineColor.CGColor
-        self.fillColor = barColor.CGColor
+        self.strokeColor = barLineColor.cgColor
+        self.fillColor = barColor.cgColor
         
         self.lineJoin = lineJoin
         self.lineCap = lineCap
@@ -1347,7 +1340,7 @@ private class BarDrawingLayer: ScrollableGraphViewDrawingLayer {
         
         let squarePath = UIBezierPath()
         
-        squarePath.moveToPoint(centre)
+        squarePath.move(to: centre)
         let barWidthOffset: CGFloat = self.barWidth / 2
         
         let topLeft = CGPoint(x: centre.x - barWidthOffset, y: centre.y)
@@ -1355,11 +1348,11 @@ private class BarDrawingLayer: ScrollableGraphViewDrawingLayer {
         let bottomLeft = CGPoint(x: centre.x - barWidthOffset, y: zeroYPosition)
         let bottomRight = CGPoint(x: centre.x + barWidthOffset, y: zeroYPosition)
         
-        squarePath.moveToPoint(topLeft)
-        squarePath.addLineToPoint(topRight)
-        squarePath.addLineToPoint(bottomRight)
-        squarePath.addLineToPoint(bottomLeft)
-        squarePath.addLineToPoint(topLeft)
+        squarePath.move(to: topLeft)
+        squarePath.addLine(to: topRight)
+        squarePath.addLine(to: bottomRight)
+        squarePath.addLine(to: bottomLeft)
+        squarePath.addLine(to: topLeft)
         
         return squarePath
     }
@@ -1377,14 +1370,14 @@ private class BarDrawingLayer: ScrollableGraphViewDrawingLayer {
         
         for i in activePointsInterval {
             
-            var location = CGPointZero
+            var location = CGPoint.zero
             
-            if let pointLocation = self.graphViewDrawingDelegate?.graphPointForIndex(i).location {
+            if let pointLocation = self.graphViewDrawingDelegate?.graphPoint(forIndex: i).location {
                 location = pointLocation
             }
             
-            let pointPath = createBarPath(location)
-            barPath.appendPath(pointPath)
+            let pointPath = createBarPath(centre: location)
+            barPath.append(pointPath)
         }
         
         return barPath
@@ -1392,7 +1385,7 @@ private class BarDrawingLayer: ScrollableGraphViewDrawingLayer {
     
     override func updatePath() {
         
-        self.path = createPath ().CGPath
+        self.path = createPath ().cgPath
     }
     
 }
@@ -1404,13 +1397,13 @@ private class LineDrawingLayer : ScrollableGraphViewDrawingLayer {
         super.init(viewportWidth: frame.size.width, viewportHeight: frame.size.height)
         
         self.lineWidth = lineWidth
-        self.strokeColor = lineColor.CGColor
+        self.strokeColor = lineColor.cgColor
         
         self.lineJoin = lineJoin
         self.lineCap = lineCap
         
         // Setup
-        self.fillColor = UIColor.clearColor().CGColor // This is handled by the fill drawing layer.
+        self.fillColor = UIColor.clear.cgColor // This is handled by the fill drawing layer.
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -1418,7 +1411,7 @@ private class LineDrawingLayer : ScrollableGraphViewDrawingLayer {
     }
     
     override func updatePath() {
-        self.path = graphViewDrawingDelegate?.currentPath().CGPath
+        self.path = graphViewDrawingDelegate?.currentPath().cgPath
     }
 }
 
@@ -1427,11 +1420,11 @@ private class DataPointDrawingLayer: ScrollableGraphViewDrawingLayer {
     
     private var dataPointPath = UIBezierPath()
     private var dataPointSize: CGFloat = 5
-    private var dataPointType: ScrollableGraphViewDataPointType = .Circle
+    private var dataPointType: ScrollableGraphViewDataPointType = .circle
     
-    private var customDataPointPath: ((centre: CGPoint) -> UIBezierPath)?
+    private var customDataPointPath: ((_ centre: CGPoint) -> UIBezierPath)?
     
-    init(frame: CGRect, fillColor: UIColor, dataPointType: ScrollableGraphViewDataPointType, dataPointSize: CGFloat, customDataPointPath: ((centre: CGPoint) -> UIBezierPath)? = nil) {
+    init(frame: CGRect, fillColor: UIColor, dataPointType: ScrollableGraphViewDataPointType, dataPointSize: CGFloat, customDataPointPath: ((_ centre: CGPoint) -> UIBezierPath)? = nil) {
         
         self.dataPointType = dataPointType
         self.dataPointSize = dataPointSize
@@ -1439,7 +1432,7 @@ private class DataPointDrawingLayer: ScrollableGraphViewDrawingLayer {
         
         super.init(viewportWidth: frame.size.width, viewportHeight: frame.size.height)
         
-        self.fillColor = fillColor.CGColor
+        self.fillColor = fillColor.cgColor
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -1461,14 +1454,14 @@ private class DataPointDrawingLayer: ScrollableGraphViewDrawingLayer {
         
         for i in activePointsInterval {
             
-            var location = CGPointZero
+            var location = CGPoint.zero
             
-            if let pointLocation = self.graphViewDrawingDelegate?.graphPointForIndex(i).location {
+            if let pointLocation = self.graphViewDrawingDelegate?.graphPoint(forIndex: i).location {
                 location = pointLocation
             }
             
-            let pointPath = pointPathCreator(centre: location)
-            dataPointPath.appendPath(pointPath)
+            let pointPath = pointPathCreator(location)
+            dataPointPath.append(pointPath)
         }
         
         return dataPointPath
@@ -1482,29 +1475,29 @@ private class DataPointDrawingLayer: ScrollableGraphViewDrawingLayer {
         
         let squarePath = UIBezierPath()
         
-        squarePath.moveToPoint(centre)
+        squarePath.move(to: centre)
         
         let topLeft = CGPoint(x: centre.x - dataPointSize, y: centre.y - dataPointSize)
         let topRight = CGPoint(x: centre.x + dataPointSize, y: centre.y - dataPointSize)
         let bottomLeft = CGPoint(x: centre.x - dataPointSize, y: centre.y + dataPointSize)
         let bottomRight = CGPoint(x: centre.x + dataPointSize, y: centre.y + dataPointSize)
         
-        squarePath.moveToPoint(topLeft)
-        squarePath.addLineToPoint(topRight)
-        squarePath.addLineToPoint(bottomRight)
-        squarePath.addLineToPoint(bottomLeft)
-        squarePath.addLineToPoint(topLeft)
+        squarePath.move(to: topLeft)
+        squarePath.addLine(to: topRight)
+        squarePath.addLine(to: bottomRight)
+        squarePath.addLine(to: bottomLeft)
+        squarePath.addLine(to: topLeft)
         
         return squarePath
     }
     
-    private func getPointPathCreator() -> (centre: CGPoint) -> UIBezierPath {
+    private func getPointPathCreator() -> (_ centre: CGPoint) -> UIBezierPath {
         switch(self.dataPointType) {
-        case .Circle:
+        case .circle:
             return createCircleDataPoint
-        case .Square:
+        case .square:
             return createSquareDataPoint
-        case .Custom:
+        case .custom:
             if let customCreator = self.customDataPointPath {
                 return customCreator
             }
@@ -1518,7 +1511,7 @@ private class DataPointDrawingLayer: ScrollableGraphViewDrawingLayer {
     }
     
     override func updatePath() {
-        self.path = createDataPointPath().CGPath
+        self.path = createDataPointPath().cgPath
     }
 }
 
@@ -1534,7 +1527,7 @@ private class GradientDrawingLayer : ScrollableGraphViewDrawingLayer {
         
         mask.frame = CGRect(x: 0, y: 0, width: self.viewportWidth, height: self.viewportHeight)
         mask.fillRule = kCAFillRuleEvenOdd
-        mask.path = self.graphViewDrawingDelegate?.currentPath().CGPath
+        mask.path = self.graphViewDrawingDelegate?.currentPath().cgPath
         mask.lineJoin = self.lineJoin
         
         return mask
@@ -1561,15 +1554,15 @@ private class GradientDrawingLayer : ScrollableGraphViewDrawingLayer {
     }
     
     override func updatePath() {
-        gradientMask.path = graphViewDrawingDelegate?.currentPath().CGPath
+        gradientMask.path = graphViewDrawingDelegate?.currentPath().cgPath
     }
     
-    override func drawInContext(ctx: CGContext) {
+    override func draw(in ctx: CGContext) {
         
-        let colors = [startColor.CGColor, endColor.CGColor]
+        let colors = [startColor.cgColor, endColor.cgColor]
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let locations: [CGFloat] = [0.0, 1.0]
-        let gradient = CGGradientCreateWithColors(colorSpace, colors, locations)
+        let gradient = CGGradient(colorsSpace: colorSpace, colors: colors as CFArray, locations: locations)
         
         let displacement = ((viewportWidth / viewportHeight) / 2.5) * self.bounds.height
         let topCentre = CGPoint(x: offset + self.bounds.width / 2, y: -displacement)
@@ -1578,10 +1571,10 @@ private class GradientDrawingLayer : ScrollableGraphViewDrawingLayer {
         let endRadius: CGFloat = self.bounds.width
         
         switch(gradientType) {
-        case .Linear:
-            CGContextDrawLinearGradient(ctx, gradient, topCentre, bottomCentre, .DrawsAfterEndLocation)
-        case .Radial:
-            CGContextDrawRadialGradient(ctx, gradient, topCentre, startRadius, topCentre, endRadius, .DrawsAfterEndLocation)
+        case .linear:
+            ctx.drawLinearGradient(gradient!, start: topCentre, end: bottomCentre, options: .drawsAfterEndLocation)
+        case .radial:
+            ctx.drawRadialGradient(gradient!, startCenter: topCentre, startRadius: startRadius, endCenter: topCentre, endRadius: endRadius, options: .drawsAfterEndLocation)
         }
     }
 }
@@ -1591,7 +1584,7 @@ private class FillDrawingLayer : ScrollableGraphViewDrawingLayer {
     
     init(frame: CGRect, fillColor: UIColor) {
         super.init(viewportWidth: frame.size.width, viewportHeight: frame.size.height)
-        self.fillColor = fillColor.CGColor
+        self.fillColor = fillColor.cgColor
     }
     
     required init?(coder aDecoder: NSCoder) {
@@ -1599,7 +1592,7 @@ private class FillDrawingLayer : ScrollableGraphViewDrawingLayer {
     }
     
     override func updatePath() {
-        self.path = graphViewDrawingDelegate?.currentPath().CGPath
+        self.path = graphViewDrawingDelegate?.currentPath().cgPath
     }
 }
 
@@ -1610,10 +1603,10 @@ private class ReferenceLineDrawingView : UIView {
     // PUBLIC PROPERTIES
     
     // Reference line settings.
-    var referenceLineColor: UIColor = UIColor.blackColor()
+    var referenceLineColor: UIColor = UIColor.black
     var referenceLineThickness: CGFloat = 0.5
-    var referenceLinePosition = ScrollableGraphViewReferenceLinePosition.Left
-    var referenceLineType = ScrollableGraphViewReferenceLineType.Cover
+    var referenceLinePosition = ScrollableGraphViewReferenceLinePosition.left
+    var referenceLineType = ScrollableGraphViewReferenceLineType.cover
     
     var numberOfIntermediateReferenceLines = 3 // Number of reference lines between the min and max line.
     
@@ -1622,10 +1615,10 @@ private class ReferenceLineDrawingView : UIView {
     var shouldAddUnitsToIntermediateReferenceLineLabels: Bool = false
     
     var labelUnits: String?
-    var labelFont: UIFont = UIFont.systemFontOfSize(8)
-    var labelColor: UIColor = UIColor.blackColor()
+    var labelFont: UIFont = UIFont.systemFont(ofSize: 8)
+    var labelColor: UIColor = UIColor.black
     var labelDecimalPlaces: Int = 2
-    var labelNumberStyle: NSNumberFormatterStyle = .NoStyle
+    var labelNumberStyle: NumberFormatter.Style = .none
     
     // PRIVATE PROPERTIES
     
@@ -1646,7 +1639,7 @@ private class ReferenceLineDrawingView : UIView {
     
     private var lineWidth: CGFloat {
         get {
-            if(self.referenceLineType == ScrollableGraphViewReferenceLineType.Cover) {
+            if(self.referenceLineType == ScrollableGraphViewReferenceLineType.cover) {
                 return self.bounds.width
             }
             else {
@@ -1678,7 +1671,7 @@ private class ReferenceLineDrawingView : UIView {
         
         // The reference line layer draws the reference lines and we handle the labels elsewhere.
         self.referenceLineLayer.frame = self.frame
-        self.referenceLineLayer.strokeColor = referenceLineColor.CGColor
+        self.referenceLineLayer.strokeColor = referenceLineColor.cgColor
         self.referenceLineLayer.lineWidth = referenceLineThickness
         
         self.layer.addSublayer(referenceLineLayer)
@@ -1688,7 +1681,7 @@ private class ReferenceLineDrawingView : UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
-    private func createLabelAtPosition(position: CGPoint, withText text: String) -> UILabel {
+    private func createLabel(at position: CGPoint, withText text: String) -> UILabel {
         let frame = CGRect(x: position.x, y: position.y, width: 0, height: 0)
         let label = UILabel(frame: frame)
         
@@ -1711,21 +1704,21 @@ private class ReferenceLineDrawingView : UIView {
         
         let numberFormatter = referenceNumberFormatter()
         
-        let maxString = numberFormatter.stringFromNumber(self.currentRange.max)! + units
-        let minString = numberFormatter.stringFromNumber(self.currentRange.min)! + units
+        let maxString = numberFormatter.string(from: self.currentRange.max as NSNumber)! + units
+        let minString = numberFormatter.string(from: self.currentRange.min as NSNumber)! + units
         
-        addLineWithTag(maxString, from: maxLineStart, to: maxLineEnd, inPath: referenceLinePath)
-        addLineWithTag(minString, from: minLineStart, to: minLineEnd, inPath: referenceLinePath)
+        addLine(withTag: maxString, from: maxLineStart, to: maxLineEnd, in: referenceLinePath)
+        addLine(withTag: minString, from: minLineStart, to: minLineEnd, in: referenceLinePath)
         
         let initialRect = CGRect(x: self.bounds.origin.x, y: self.bounds.origin.y + topMargin, width: self.bounds.size.width, height: self.bounds.size.height - (topMargin + bottomMargin))
         
-        createIntermediateReferenceLines(initialRect, numberOfIntermediateReferenceLines: self.numberOfIntermediateReferenceLines, forPath: referenceLinePath)
+        createIntermediateReferenceLines(in: initialRect, numberOfIntermediateReferenceLines: self.numberOfIntermediateReferenceLines, for: referenceLinePath)
         
         return referenceLinePath
     }
     
-    private func referenceNumberFormatter() -> NSNumberFormatter {
-        let numberFormatter = NSNumberFormatter()
+    private func referenceNumberFormatter() -> NumberFormatter {
+        let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = labelNumberStyle
         numberFormatter.minimumFractionDigits = labelDecimalPlaces
         numberFormatter.maximumFractionDigits = labelDecimalPlaces
@@ -1733,7 +1726,7 @@ private class ReferenceLineDrawingView : UIView {
         return numberFormatter
     }
     
-    private func createIntermediateReferenceLines(rect: CGRect, numberOfIntermediateReferenceLines: Int, forPath path: UIBezierPath) {
+    private func createIntermediateReferenceLines(in rect: CGRect, numberOfIntermediateReferenceLines: Int, for path: UIBezierPath) {
         
         let height = rect.size.height
         let spacePerPartition = height / CGFloat(numberOfIntermediateReferenceLines + 1)
@@ -1743,12 +1736,13 @@ private class ReferenceLineDrawingView : UIView {
             let lineStart = CGPoint(x: 0, y: rect.origin.y + (spacePerPartition * CGFloat(i + 1)))
             let lineEnd = CGPoint(x: lineStart.x + lineWidth * intermediateLineWidthMultiplier, y: lineStart.y)
             
-            createReferenceLineFrom(from: lineStart, to: lineEnd, inPath: path)
+            createReferenceLineFrom(from: lineStart, to: lineEnd, in: path)
         }
     }
     
     // FUTURE: Can use the recursive version to create a ruler like look on the edge.
-    private func recursiveCreateIntermediateReferenceLines(rect: CGRect, width: CGFloat, forPath path: UIBezierPath, remainingPartitions: Int) -> UIBezierPath {
+    @discardableResult
+    private func recursiveCreateIntermediateReferenceLines(in rect: CGRect, width: CGFloat, for path: UIBezierPath, remainingPartitions: Int) -> UIBezierPath {
         
         if(remainingPartitions <= 0) {
             return path
@@ -1757,7 +1751,7 @@ private class ReferenceLineDrawingView : UIView {
         let lineStart = CGPoint(x: 0, y: rect.origin.y + (rect.size.height / 2))
         let lineEnd = CGPoint(x: lineStart.x + width, y: lineStart.y)
         
-        createReferenceLineFrom(from: lineStart, to: lineEnd, inPath: path)
+        createReferenceLineFrom(from: lineStart, to: lineEnd, in: path)
         
         let topRect = CGRect(
             x: rect.origin.x,
@@ -1771,35 +1765,35 @@ private class ReferenceLineDrawingView : UIView {
             width: rect.size.width,
             height: rect.size.height / 2)
         
-        recursiveCreateIntermediateReferenceLines(topRect, width: width * intermediateLineWidthMultiplier, forPath: path, remainingPartitions: remainingPartitions - 1)
-        recursiveCreateIntermediateReferenceLines(bottomRect, width: width * intermediateLineWidthMultiplier, forPath: path, remainingPartitions: remainingPartitions - 1)
+        recursiveCreateIntermediateReferenceLines(in: topRect, width: width * intermediateLineWidthMultiplier, for: path, remainingPartitions: remainingPartitions - 1)
+        recursiveCreateIntermediateReferenceLines(in: bottomRect, width: width * intermediateLineWidthMultiplier, for: path, remainingPartitions: remainingPartitions - 1)
         
         return path
     }
     
-    private func createReferenceLineFrom(from lineStart: CGPoint, to lineEnd: CGPoint, inPath path: UIBezierPath) {
+    private func createReferenceLineFrom(from lineStart: CGPoint, to lineEnd: CGPoint, in path: UIBezierPath) {
         if(shouldAddLabelsToIntermediateReferenceLines) {
             
-            let value = calculateYAxisValueForPoint(lineStart)
+            let value = calculateYAxisValue(for: lineStart)
             let numberFormatter = referenceNumberFormatter()
-            var valueString = numberFormatter.stringFromNumber(value)!
+            var valueString = numberFormatter.string(from: value as NSNumber)!
             
             if(shouldAddUnitsToIntermediateReferenceLineLabels) {
                 valueString += " \(units)"
             }
             
-            addLineWithTag(valueString, from: lineStart, to: lineEnd, inPath: path)
+            addLine(withTag: valueString, from: lineStart, to: lineEnd, in: path)
             
         } else {
-            addLineFrom(lineStart, to: lineEnd, inPath: path)
+            addLine(from: lineStart, to: lineEnd, in: path)
         }
     }
     
-    private func addLineWithTag(tag: String, from: CGPoint, to: CGPoint, inPath path: UIBezierPath) {
+    private func addLine(withTag tag: String, from: CGPoint, to: CGPoint, in path: UIBezierPath) {
         
-        let boundingSize = boundingSizeForText(tag)
-        let leftLabel = createLabelWithText(tag)
-        let rightLabel = createLabelWithText(tag)
+        let boundingSize = self.boundingSize(forText: tag)
+        let leftLabel = createLabel(withText: tag)
+        let rightLabel = createLabel(withText: tag)
         
         // Left label gap.
         leftLabel.frame = CGRect(
@@ -1822,17 +1816,17 @@ private class ReferenceLineDrawingView : UIView {
         
         switch(self.referenceLinePosition) {
             
-        case .Left:
+        case .left:
             gaps.append((start: leftLabelStart.x, end: leftLabelEnd.x))
             self.addSubview(leftLabel)
             self.labels.append(leftLabel)
             
-        case .Right:
+        case .right:
             gaps.append((start: rightLabelStart.x, end: rightLabelEnd.x))
             self.addSubview(rightLabel)
             self.labels.append(rightLabel)
             
-        case .Both:
+        case .both:
             gaps.append((start: leftLabelStart.x, end: leftLabelEnd.x))
             gaps.append((start: rightLabelStart.x, end: rightLabelEnd.x))
             self.addSubview(leftLabel)
@@ -1841,14 +1835,14 @@ private class ReferenceLineDrawingView : UIView {
             self.labels.append(rightLabel)
         }
         
-        addLineWithGaps(from, to: to, withGaps: gaps, inPath: path)
+        addLine(from: from, to: to, withGaps: gaps, in: path)
     }
     
-    private func addLineWithGaps(from: CGPoint, to: CGPoint, withGaps gaps: [(start: CGFloat, end: CGFloat)], inPath path: UIBezierPath) {
+    private func addLine(from: CGPoint, to: CGPoint, withGaps gaps: [(start: CGFloat, end: CGFloat)], in path: UIBezierPath) {
         
         // If there are no gaps, just add a single line.
         if(gaps.count <= 0) {
-            addLineFrom(from, to: to, inPath: path)
+            addLine(from: from, to: to, in: path)
         }
             // If there is only 1 gap, it's just two lines.
         else if (gaps.count == 1) {
@@ -1856,8 +1850,8 @@ private class ReferenceLineDrawingView : UIView {
             let gapLeft = CGPoint(x: gaps.first!.start, y: from.y)
             let gapRight = CGPoint(x: gaps.first!.end, y: from.y)
             
-            addLineFrom(from, to: gapLeft, inPath: path)
-            addLineFrom(gapRight, to: to, inPath: path)
+            addLine(from: from, to: gapLeft, in: path)
+            addLine(from: gapRight, to: to, in: path)
         }
             // If there are many gaps, we have a series of intermediate lines.
         else {
@@ -1869,7 +1863,7 @@ private class ReferenceLineDrawingView : UIView {
             let lastGapRight = CGPoint(x: lastGap.end, y: to.y)
             
             // Add the first line to the start of the first gap
-            addLineFrom(from, to: firstGapLeft, inPath: path)
+            addLine(from: from, to: firstGapLeft, in: path)
             
             // Add lines between all intermediate gaps
             for i in 0 ..< gaps.count - 1 {
@@ -1880,24 +1874,24 @@ private class ReferenceLineDrawingView : UIView {
                 let lineStart = CGPoint(x: startGapEnd, y: from.y)
                 let lineEnd = CGPoint(x: endGapStart, y: from.y)
                 
-                addLineFrom(lineStart, to: lineEnd, inPath: path)
+                addLine(from: lineStart, to: lineEnd, in: path)
             }
             
             // Add the final line to the end
-            addLineFrom(lastGapRight, to: to, inPath: path)
+            addLine(from: lastGapRight, to: to, in: path)
         }
     }
     
-    private func addLineFrom(from: CGPoint, to: CGPoint, inPath path: UIBezierPath) {
-        path.moveToPoint(from)
-        path.addLineToPoint(to)
+    private func addLine(from: CGPoint, to: CGPoint, in path: UIBezierPath) {
+        path.move(to: from)
+        path.addLine(to: to)
     }
     
-    private func boundingSizeForText(text: String) -> CGSize {
-        return (text as NSString).sizeWithAttributes([NSFontAttributeName:labelFont])
+    private func boundingSize(forText text: String) -> CGSize {
+        return (text as NSString).size(attributes: [NSFontAttributeName:labelFont])
     }
     
-    private func calculateYAxisValueForPoint(point: CGPoint) -> Double {
+    private func calculateYAxisValue(for point: CGPoint) -> Double {
         
         let graphHeight = self.frame.size.height - (topMargin + bottomMargin)
         
@@ -1918,7 +1912,7 @@ private class ReferenceLineDrawingView : UIView {
         return Double(value)
     }
     
-    private func createLabelWithText(text: String) -> UILabel {
+    private func createLabel(withText text: String) -> UILabel {
         let label = UILabel()
         
         label.text = text
@@ -1930,70 +1924,70 @@ private class ReferenceLineDrawingView : UIView {
     
     // Public functions to update the reference lines with any changes to the range and viewport (phone rotation, etc).
     // When the range changes, need to update the max for the new range, then update all the labels that are showing for the axis and redraw the reference lines.
-    func setRange(range: (min: Double, max: Double)) {
+    func set(range: (min: Double, max: Double)) {
         self.currentRange = range
-        self.referenceLineLayer.path = createReferenceLinesPath().CGPath
+        self.referenceLineLayer.path = createReferenceLinesPath().cgPath
     }
     
-    func setViewport(viewportWidth: CGFloat, viewportHeight: CGFloat) {
+    func set(viewportWidth: CGFloat, viewportHeight: CGFloat) {
         self.frame.size.width = viewportWidth
         self.frame.size.height = viewportHeight
-        self.referenceLineLayer.path = createReferenceLinesPath().CGPath
+        self.referenceLineLayer.path = createReferenceLinesPath().cgPath
     }
 }
 
 // MARK: - ScrollableGraphView Settings Enums
 
 @objc public enum ScrollableGraphViewLineStyle : Int {
-    case Straight
-    case Smooth
+    case straight
+    case smooth
 }
 
 @objc public enum ScrollableGraphViewFillType : Int {
-    case Solid
-    case Gradient
+    case solid
+    case gradient
 }
 
 @objc public enum ScrollableGraphViewGradientType : Int {
-    case Linear
-    case Radial
+    case linear
+    case radial
 }
 
 @objc public enum ScrollableGraphViewDataPointType : Int {
-    case Circle
-    case Square
-    case Custom
+    case circle
+    case square
+    case custom
 }
 
 @objc public enum ScrollableGraphViewReferenceLinePosition : Int {
-    case Left
-    case Right
-    case Both
+    case left
+    case right
+    case both
 }
 
 @objc public enum ScrollableGraphViewReferenceLineType : Int {
-    case Cover
+    case cover
     //case Edge // FUTURE: Implement
 }
 
 @objc public enum ScrollableGraphViewAnimationType : Int {
-    case EaseOut
-    case Elastic
-    case Custom
+    case easeOut
+    case elastic
+    case custom
 }
 
 @objc public enum ScrollableGraphViewDirection : Int {
-    case LeftToRight
-    case RightToLeft
+    case leftToRight
+    case rightToLeft
 }
 
 // Simplified easing functions from: http://www.joshondesign.com/2013/03/01/improvedEasingEquations
 private struct Easings {
     
-    static let EaseInQuad =  { (t:Double) -> Double in  return t*t; }
-    static let EaseOutQuad = { (t:Double) -> Double in  return 1 - Easings.EaseInQuad(1-t); }
+    static let easeInQuad =  { (t:Double) -> Double in  return t*t; }
+    static let easeOutQuad = { (t:Double) -> Double in  return 1 - Easings.easeInQuad(1-t); }
     
-    static let EaseOutElastic = { (t: Double) -> Double in
+    static let easeOutElastic = { (t: Double) -> Double in
         var p = 0.3;
         return pow(2,-10*t) * sin((t-p/4)*(2*M_PI)/p) + 1;
     }

--- a/Classes/ScrollableGraphView.swift
+++ b/Classes/ScrollableGraphView.swift
@@ -319,8 +319,6 @@ import UIKit
         // Make sure everything is in a clean state.
         reset()
         
-        self.delegate = self
-        
         // Calculate the viewport and drawing frames.
         self.viewportWidth = self.frame.width
         self.viewportHeight = self.frame.height

--- a/graphview_example_code/GraphView.xcodeproj/project.pbxproj
+++ b/graphview_example_code/GraphView.xcodeproj/project.pbxproj
@@ -115,10 +115,11 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				TargetAttributes = {
 					2918399D1C72E6A400753A45 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -200,8 +201,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -244,8 +247,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -264,6 +269,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.2;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -279,6 +285,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ios.GraphView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -293,6 +300,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ios.GraphView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/graphview_example_code/GraphView/AppDelegate.swift
+++ b/graphview_example_code/GraphView/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/graphview_example_code/GraphView/UIColor+colorFromHex.swift
+++ b/graphview_example_code/GraphView/UIColor+colorFromHex.swift
@@ -9,13 +9,13 @@ extension UIColor {
     // Convert a hex string to a UIColor object.
     class func colorFromHex(hexString:String) -> UIColor {
         
-        func cleanHexString(hexString: String) -> String {
+        func clean(hexString: String) -> String {
             
             var cleanedHexString = String()
             
             // Remove the leading "#"
             if(hexString[hexString.startIndex] == "#") {
-                cleanedHexString = hexString.substringFromIndex(hexString.startIndex.advancedBy(1))
+                cleanedHexString = hexString.substring(from: hexString.characters.index(hexString.startIndex, offsetBy: 1))
             }
             
             // TODO: Other cleanup. Allow for a "short" hex string, i.e., "#fff"
@@ -23,21 +23,21 @@ extension UIColor {
             return cleanedHexString
         }
         
-        let cleanedHexString = cleanHexString(hexString)
+        let cleanedHexString = clean(hexString: hexString)
         
         // If we can get a cached version of the colour, get out early.
-        if let cachedColor = UIColor.getColorFromCache(cleanedHexString) {
+        if let cachedColor = UIColor.getColorFromCache(hexString: cleanedHexString) {
             return cachedColor
         }
         
         // Else create the color, store it in the cache and return.
-        let scanner = NSScanner(string: cleanedHexString)
+        let scanner = Scanner(string: cleanedHexString)
         
         var value:UInt32 = 0
         
         // We have the hex value, grab the red, green, blue and alpha values.
         // Have to pass value by reference, scanner modifies this directly as the result of scanning the hex string. The return value is the success or fail.
-        if(scanner.scanHexInt(&value)){
+        if(scanner.scanHexInt32(&value)){
             
             // intValue = 01010101 11110111 11101010    // binary
             // intValue = 55       F7       EA          // hexadecimal
@@ -70,10 +70,10 @@ extension UIColor {
             // red, green, blue and alpha are currently between 0 and 255
             // We want to normalise these values between 0 and 1 to use with UIColor.
             let colors:[UInt32] = [red, green, blue]
-            let normalised = normaliseColors(colors)
+            let normalised = normalise(colors: colors)
             
             let newColor = UIColor(red: normalised[0], green: normalised[1], blue: normalised[2], alpha: 1)
-            UIColor.storeColorInCache(cleanedHexString, color: newColor)
+            UIColor.storeColorInCache(hexString: cleanedHexString, color: newColor)
             
             return newColor
             
@@ -81,12 +81,12 @@ extension UIColor {
             // We couldn't get a value from a valid hex string.
         else {
             print("Error: Couldn't convert the hex string to a number, returning UIColor.whiteColor() instead.")
-            return UIColor.whiteColor()
+            return UIColor.white
         }
     }
     
     // Takes an array of colours in the range of 0-255 and returns a value between 0 and 1.
-    private class func normaliseColors(colors: [UInt32]) -> [CGFloat]{
+    private class func normalise(colors: [UInt32]) -> [CGFloat]{
         var normalisedVersions = [CGFloat]()
         
         for color in colors{

--- a/graphview_example_code/GraphView/ViewController.swift
+++ b/graphview_example_code/GraphView/ViewController.swift
@@ -8,7 +8,7 @@ import UIKit
 class ViewController: UIViewController {
 
     var graphView = ScrollableGraphView()
-    var currentGraphType = GraphType.Dark
+    var currentGraphType = GraphType.dark
     var graphConstraints = [NSLayoutConstraint]()
     
     var label = UILabel()
@@ -27,7 +27,7 @@ class ViewController: UIViewController {
         graphView = ScrollableGraphView(frame: self.view.frame)
         graphView = createDarkGraph(self.view.frame)
         
-        graphView.setData(data, withLabels: labels)
+        graphView.set(data: data, withLabels: labels)
         self.view.addSubview(graphView)
         
         setupConstraints()
@@ -35,7 +35,7 @@ class ViewController: UIViewController {
         addLabel(withText: "DARK (TAP HERE)")
     }
     
-    func didTap(gesture: UITapGestureRecognizer) {
+    func didTap(_ gesture: UITapGestureRecognizer) {
         
         currentGraphType.next()
         
@@ -43,55 +43,55 @@ class ViewController: UIViewController {
         graphView.removeFromSuperview()
         
         switch(currentGraphType) {
-        case .Dark:
+        case .dark:
             addLabel(withText: "DARK")
             graphView = createDarkGraph(self.view.frame)
-        case .Dot:
+        case .dot:
             addLabel(withText: "DOT")
             graphView = createDotGraph(self.view.frame)
-        case .Bar:
+        case .bar:
             addLabel(withText: "BAR")
             graphView = createBarGraph(self.view.frame)
-        case .Pink:
+        case .pink:
             addLabel(withText: "PINK")
             graphView = createPinkMountainGraph(self.view.frame)
         }
         
-        graphView.setData(data, withLabels: labels)
+        graphView.set(data: data, withLabels: labels)
         self.view.insertSubview(graphView, belowSubview: label)
         
         setupConstraints()
     }
     
-    private func createDarkGraph(frame: CGRect) -> ScrollableGraphView {
+    fileprivate func createDarkGraph(_ frame: CGRect) -> ScrollableGraphView {
         let graphView = ScrollableGraphView(frame: frame)
 
-        graphView.backgroundFillColor = UIColor.colorFromHex("#333333")
+        graphView.backgroundFillColor = UIColor.colorFromHex(hexString: "#333333")
         
         graphView.lineWidth = 1
-        graphView.lineColor = UIColor.colorFromHex("#777777")
-        graphView.lineStyle = ScrollableGraphViewLineStyle.Smooth
+        graphView.lineColor = UIColor.colorFromHex(hexString: "#777777")
+        graphView.lineStyle = ScrollableGraphViewLineStyle.smooth
         
         graphView.shouldFill = true
-        graphView.fillType = ScrollableGraphViewFillType.Gradient
-        graphView.fillColor = UIColor.colorFromHex("#555555")
-        graphView.fillGradientType = ScrollableGraphViewGradientType.Linear
-        graphView.fillGradientStartColor = UIColor.colorFromHex("#555555")
-        graphView.fillGradientEndColor = UIColor.colorFromHex("#444444")
+        graphView.fillType = ScrollableGraphViewFillType.gradient
+        graphView.fillColor = UIColor.colorFromHex(hexString: "#555555")
+        graphView.fillGradientType = ScrollableGraphViewGradientType.linear
+        graphView.fillGradientStartColor = UIColor.colorFromHex(hexString: "#555555")
+        graphView.fillGradientEndColor = UIColor.colorFromHex(hexString: "#444444")
 
         graphView.dataPointSpacing = 80
         graphView.dataPointSize = 2
-        graphView.dataPointFillColor = UIColor.whiteColor()
+        graphView.dataPointFillColor = UIColor.white
 
-        graphView.referenceLineLabelFont = UIFont.boldSystemFontOfSize(8)
-        graphView.referenceLineColor = UIColor.whiteColor().colorWithAlphaComponent(0.2)
-        graphView.referenceLineLabelColor = UIColor.whiteColor()
+        graphView.referenceLineLabelFont = UIFont.boldSystemFont(ofSize: 8)
+        graphView.referenceLineColor = UIColor.white.withAlphaComponent(0.2)
+        graphView.referenceLineLabelColor = UIColor.white
         graphView.numberOfIntermediateReferenceLines = 5
-        graphView.dataPointLabelColor = UIColor.whiteColor().colorWithAlphaComponent(0.5)
+        graphView.dataPointLabelColor = UIColor.white.withAlphaComponent(0.5)
         
         graphView.shouldAnimateOnStartup = true
         graphView.shouldAdaptRange = true
-        graphView.adaptAnimationType = ScrollableGraphViewAnimationType.Elastic
+        graphView.adaptAnimationType = ScrollableGraphViewAnimationType.elastic
         graphView.animationDuration = 1.5
         graphView.rangeMax = 50
         graphView.shouldRangeAlwaysStartAtZero = true
@@ -99,29 +99,29 @@ class ViewController: UIViewController {
         return graphView
     }
     
-    private func createBarGraph(frame: CGRect) -> ScrollableGraphView {
+    private func createBarGraph(_ frame: CGRect) -> ScrollableGraphView {
         let graphView = ScrollableGraphView(frame:frame)
         
-        graphView.dataPointType = ScrollableGraphViewDataPointType.Circle
+        graphView.dataPointType = ScrollableGraphViewDataPointType.circle
         graphView.shouldDrawBarLayer = true
         graphView.shouldDrawDataPoint = false
     
-        graphView.lineColor = UIColor.clearColor()
+        graphView.lineColor = UIColor.clear
         graphView.barWidth = 25
         graphView.barLineWidth = 1
-        graphView.barLineColor = UIColor.colorFromHex("#777777")
-        graphView.barColor = UIColor.colorFromHex("#555555")
-        graphView.backgroundFillColor = UIColor.colorFromHex("#333333")
+        graphView.barLineColor = UIColor.colorFromHex(hexString: "#777777")
+        graphView.barColor = UIColor.colorFromHex(hexString: "#555555")
+        graphView.backgroundFillColor = UIColor.colorFromHex(hexString: "#333333")
         
-        graphView.referenceLineLabelFont = UIFont.boldSystemFontOfSize(8)
-        graphView.referenceLineColor = UIColor.whiteColor().colorWithAlphaComponent(0.2)
-        graphView.referenceLineLabelColor = UIColor.whiteColor()
+        graphView.referenceLineLabelFont = UIFont.boldSystemFont(ofSize: 8)
+        graphView.referenceLineColor = UIColor.white.withAlphaComponent(0.2)
+        graphView.referenceLineLabelColor = UIColor.white
         graphView.numberOfIntermediateReferenceLines = 5
-        graphView.dataPointLabelColor = UIColor.whiteColor().colorWithAlphaComponent(0.5)
+        graphView.dataPointLabelColor = UIColor.white.withAlphaComponent(0.5)
         
         graphView.shouldAnimateOnStartup = true
         graphView.shouldAdaptRange = true
-        graphView.adaptAnimationType = ScrollableGraphViewAnimationType.Elastic
+        graphView.adaptAnimationType = ScrollableGraphViewAnimationType.elastic
         graphView.animationDuration = 1.5
         graphView.rangeMax = 50
         graphView.shouldRangeAlwaysStartAtZero = true
@@ -129,23 +129,23 @@ class ViewController: UIViewController {
         return graphView
     }
     
-    private func createDotGraph(frame: CGRect) -> ScrollableGraphView {
+    private func createDotGraph(_ frame: CGRect) -> ScrollableGraphView {
         
         let graphView = ScrollableGraphView(frame:frame)
         
-        graphView.backgroundFillColor = UIColor.colorFromHex("#00BFFF")
-        graphView.lineColor = UIColor.clearColor()
+        graphView.backgroundFillColor = UIColor.colorFromHex(hexString: "#00BFFF")
+        graphView.lineColor = UIColor.clear
         
         graphView.dataPointSize = 5
         graphView.dataPointSpacing = 80
-        graphView.dataPointLabelFont = UIFont.boldSystemFontOfSize(10)
-        graphView.dataPointLabelColor = UIColor.whiteColor()
-        graphView.dataPointFillColor = UIColor.whiteColor()
+        graphView.dataPointLabelFont = UIFont.boldSystemFont(ofSize: 10)
+        graphView.dataPointLabelColor = UIColor.white
+        graphView.dataPointFillColor = UIColor.white
         
-        graphView.referenceLineLabelFont = UIFont.boldSystemFontOfSize(10)
-        graphView.referenceLineColor = UIColor.whiteColor().colorWithAlphaComponent(0.5)
-        graphView.referenceLineLabelColor = UIColor.whiteColor()
-        graphView.referenceLinePosition = ScrollableGraphViewReferenceLinePosition.Both
+        graphView.referenceLineLabelFont = UIFont.boldSystemFont(ofSize: 10)
+        graphView.referenceLineColor = UIColor.white.withAlphaComponent(0.5)
+        graphView.referenceLineLabelColor = UIColor.white
+        graphView.referenceLinePosition = ScrollableGraphViewReferenceLinePosition.both
         
         graphView.numberOfIntermediateReferenceLines = 9
         
@@ -154,28 +154,28 @@ class ViewController: UIViewController {
         return graphView
     }
     
-    private func createPinkMountainGraph(frame: CGRect) -> ScrollableGraphView {
+    private func createPinkMountainGraph(_ frame: CGRect) -> ScrollableGraphView {
         
         let graphView = ScrollableGraphView(frame:frame)
         
-        graphView.backgroundFillColor = UIColor.colorFromHex("#222222")
-        graphView.lineColor = UIColor.clearColor()
+        graphView.backgroundFillColor = UIColor.colorFromHex(hexString: "#222222")
+        graphView.lineColor = UIColor.clear
         
         graphView.shouldFill = true
-        graphView.fillColor = UIColor.colorFromHex("#FF0080")
+        graphView.fillColor = UIColor.colorFromHex(hexString: "#FF0080")
         
         graphView.shouldDrawDataPoint = false
         graphView.dataPointSpacing = 20
-        graphView.dataPointLabelFont = UIFont.boldSystemFontOfSize(10)
-        graphView.dataPointLabelColor = UIColor.whiteColor()
+        graphView.dataPointLabelFont = UIFont.boldSystemFont(ofSize: 10)
+        graphView.dataPointLabelColor = UIColor.white
       
         graphView.dataPointLabelsSparsity = 3
 
         graphView.referenceLineThickness = 1
-        graphView.referenceLineLabelFont = UIFont.boldSystemFontOfSize(10)
-        graphView.referenceLineColor = UIColor.whiteColor().colorWithAlphaComponent(0.5)
-        graphView.referenceLineLabelColor = UIColor.whiteColor()
-        graphView.referenceLinePosition = ScrollableGraphViewReferenceLinePosition.Both
+        graphView.referenceLineLabelFont = UIFont.boldSystemFont(ofSize: 10)
+        graphView.referenceLineColor = UIColor.white.withAlphaComponent(0.5)
+        graphView.referenceLineLabelColor = UIColor.white
+        graphView.referenceLinePosition = ScrollableGraphViewReferenceLinePosition.both
         
         graphView.numberOfIntermediateReferenceLines = 1
         
@@ -191,10 +191,10 @@ class ViewController: UIViewController {
         self.graphView.translatesAutoresizingMaskIntoConstraints = false
         graphConstraints.removeAll()
         
-        let topConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.Top, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Top, multiplier: 1, constant: 0)
-        let rightConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Right, multiplier: 1, constant: 0)
-        let bottomConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.Bottom, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Bottom, multiplier: 1, constant: 0)
-        let leftConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.Left, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Left, multiplier: 1, constant: 0)
+        let topConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.top, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.top, multiplier: 1, constant: 0)
+        let rightConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.right, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.right, multiplier: 1, constant: 0)
+        let bottomConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.bottom, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.bottom, multiplier: 1, constant: 0)
+        let leftConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.left, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.left, multiplier: 1, constant: 0)
         
         //let heightConstraint = NSLayoutConstraint(item: self.graphView, attribute: NSLayoutAttribute.Height, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Height, multiplier: 1, constant: 0)
         
@@ -213,14 +213,14 @@ class ViewController: UIViewController {
         
         label.removeFromSuperview()
         label = createLabel(withText: text)
-        label.userInteractionEnabled = true
+        label.isUserInteractionEnabled = true
         
-        let rightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Right, multiplier: 1, constant: -20)
+        let rightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.right, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.right, multiplier: 1, constant: -20)
         
-        let topConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Top, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Top, multiplier: 1, constant: 20)
+        let topConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.top, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.top, multiplier: 1, constant: 20)
         
-        let heightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Height, relatedBy: NSLayoutRelation.Equal, toItem: nil, attribute: NSLayoutAttribute.NotAnAttribute, multiplier: 1, constant: 40)
-        let widthConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Width, relatedBy: NSLayoutRelation.Equal, toItem: nil, attribute: NSLayoutAttribute.NotAnAttribute, multiplier: 1, constant: label.frame.width * 1.5)
+        let heightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: nil, attribute: NSLayoutAttribute.notAnAttribute, multiplier: 1, constant: 40)
+        let widthConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.width, relatedBy: NSLayoutRelation.equal, toItem: nil, attribute: NSLayoutAttribute.notAnAttribute, multiplier: 1, constant: label.frame.width * 1.5)
         
         let tapGestureRecogniser = UITapGestureRecognizer(target: self, action: #selector(didTap))
         label.addGestureRecognizer(tapGestureRecogniser)
@@ -232,12 +232,12 @@ class ViewController: UIViewController {
     private func createLabel(withText text: String) -> UILabel {
         let label = UILabel()
         
-        label.backgroundColor = UIColor.blackColor().colorWithAlphaComponent(0.5)
+        label.backgroundColor = UIColor.black.withAlphaComponent(0.5)
         
         label.text = text
-        label.textColor = UIColor.whiteColor()
-        label.textAlignment = NSTextAlignment.Center
-        label.font = UIFont.boldSystemFontOfSize(14)
+        label.textColor = UIColor.white
+        label.textAlignment = NSTextAlignment.center
+        label.font = UIFont.boldSystemFont(ofSize: 14)
         
         label.layer.cornerRadius = 2
         label.clipsToBounds = true
@@ -250,12 +250,12 @@ class ViewController: UIViewController {
     }
     
     // Data Generation
-    private func generateRandomData(numberOfItems: Int, max: Double) -> [Double] {
+    private func generateRandomData(_ numberOfItems: Int, max: Double) -> [Double] {
         var data = [Double]()
         for _ in 0 ..< numberOfItems {
-            var randomNumber = Double(random()) % max
+            var randomNumber = Double(arc4random()).truncatingRemainder(dividingBy: max)
             
-            if(random() % 100 < 10) {
+            if(arc4random() % 100 < 10) {
                 randomNumber *= 3
             }
             
@@ -264,7 +264,7 @@ class ViewController: UIViewController {
         return data
     }
     
-    private func generateSequentialLabels(numberOfItems: Int, text: String) -> [String] {
+    private func generateSequentialLabels(_ numberOfItems: Int, text: String) -> [String] {
         var labels = [String]()
         for i in 0 ..< numberOfItems {
             labels.append("\(text) \(i+1)")
@@ -274,26 +274,26 @@ class ViewController: UIViewController {
     
     // The type of the current graph we are showing.
     enum GraphType {
-        case Dark
-        case Bar
-        case Dot
-        case Pink
+        case dark
+        case bar
+        case dot
+        case pink
         
         mutating func next() {
             switch(self) {
-            case .Dark:
-                self = GraphType.Bar
-            case .Bar:
-                self = GraphType.Dot
-            case .Dot:
-                self = GraphType.Pink
-            case .Pink:
-                self = GraphType.Dark
+            case .dark:
+                self = GraphType.bar
+            case .bar:
+                self = GraphType.dot
+            case .dot:
+                self = GraphType.pink
+            case .pink:
+                self = GraphType.dark
             }
         }
     }
     
-    override func prefersStatusBarHidden() -> Bool {
+    override var prefersStatusBarHidden : Bool {
         return true
     }
 }

--- a/graphview_example_ib/GraphView.xcodeproj/project.pbxproj
+++ b/graphview_example_ib/GraphView.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 				TargetAttributes = {
 					2918399D1C72E6A400753A45 = {
 						CreatedOnToolsVersion = 7.2.1;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -279,6 +280,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ios.GraphView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -293,6 +295,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.ios.GraphView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/graphview_example_ib/GraphView/AppDelegate.swift
+++ b/graphview_example_ib/GraphView/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/graphview_example_ib/GraphView/GraphViewController.swift
+++ b/graphview_example_ib/GraphView/GraphViewController.swift
@@ -16,7 +16,7 @@ class GraphViewController: UIViewController {
         guard let data = data, let labels = labels else {
             return
         }
-        graphView?.setData(data, withLabels: labels)
+        graphView?.set(data: data, withLabels: labels)
     }
 
 }

--- a/graphview_example_ib/GraphView/ViewController.swift
+++ b/graphview_example_ib/GraphView/ViewController.swift
@@ -10,7 +10,7 @@ class ViewController: UIViewController {
     
     var childVC: GraphViewController?
 
-    var currentGraphType = GraphType.Dark
+    var currentGraphType = GraphType.dark
     
     var label = UILabel()
     var labelConstraints = [NSLayoutConstraint]()
@@ -18,7 +18,7 @@ class ViewController: UIViewController {
     // Data
     let numberOfDataItems = 29
     
-    lazy var data: [Double] = self.generateRandomData(self.numberOfDataItems, max: 50)
+    lazy var data: [Double] = self.generateRandomData(numberOfItems: self.numberOfDataItems, max: 50)
     lazy var labels: [String] = self.generateSequentialLabels(self.numberOfDataItems, text: "FEB")
     
     
@@ -30,14 +30,14 @@ class ViewController: UIViewController {
         addLabel(withText: "DARK (TAP HERE)")
     }
     
-    func addGraphViewController(name: String) {
-        guard let vc = self.storyboard?.instantiateViewControllerWithIdentifier(name) as? GraphViewController else {
+    func addGraphViewController(_ name: String) {
+        guard let vc = self.storyboard?.instantiateViewController(withIdentifier: name) as? GraphViewController else {
             return
         }
         
         // remove the previous child VC
         if let childVC = childVC {
-            childVC.willMoveToParentViewController(nil)
+            childVC.willMove(toParentViewController: nil)
             childVC.view.removeFromSuperview()
             childVC.removeFromParentViewController()
         }
@@ -51,18 +51,18 @@ class ViewController: UIViewController {
         vc.view.frame = view.bounds
         
         view.addSubview(vc.view)
-        vc.didMoveToParentViewController(self)
+        vc.didMove(toParentViewController: self)
         
         childVC = vc
     }
     
-    func didTap(gesture: UITapGestureRecognizer) {
+    func didTap(_ gesture: UITapGestureRecognizer) {
         
         currentGraphType.next()
         
         addGraphViewController(currentGraphType.description())
         
-        addLabel(withText: currentGraphType.description().uppercaseString)
+        addLabel(withText: currentGraphType.description().uppercased())
     }
 
     
@@ -71,14 +71,14 @@ class ViewController: UIViewController {
         
         label.removeFromSuperview()
         label = createLabel(withText: text)
-        label.userInteractionEnabled = true
+        label.isUserInteractionEnabled = true
         
-        let rightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Right, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Right, multiplier: 1, constant: -20)
+        let rightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.right, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.right, multiplier: 1, constant: -20)
         
-        let topConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Top, relatedBy: NSLayoutRelation.Equal, toItem: self.view, attribute: NSLayoutAttribute.Top, multiplier: 1, constant: 20)
+        let topConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.top, relatedBy: NSLayoutRelation.equal, toItem: self.view, attribute: NSLayoutAttribute.top, multiplier: 1, constant: 20)
         
-        let heightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Height, relatedBy: NSLayoutRelation.Equal, toItem: nil, attribute: NSLayoutAttribute.NotAnAttribute, multiplier: 1, constant: 40)
-        let widthConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.Width, relatedBy: NSLayoutRelation.Equal, toItem: nil, attribute: NSLayoutAttribute.NotAnAttribute, multiplier: 1, constant: label.frame.width * 1.5)
+        let heightConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: nil, attribute: NSLayoutAttribute.notAnAttribute, multiplier: 1, constant: 40)
+        let widthConstraint = NSLayoutConstraint(item: label, attribute: NSLayoutAttribute.width, relatedBy: NSLayoutRelation.equal, toItem: nil, attribute: NSLayoutAttribute.notAnAttribute, multiplier: 1, constant: label.frame.width * 1.5)
         
         let tapGestureRecogniser = UITapGestureRecognizer(target: self, action: #selector(didTap))
         label.addGestureRecognizer(tapGestureRecogniser)
@@ -90,12 +90,12 @@ class ViewController: UIViewController {
     private func createLabel(withText text: String) -> UILabel {
         let label = UILabel()
         
-        label.backgroundColor = UIColor.blackColor().colorWithAlphaComponent(0.5)
+        label.backgroundColor = UIColor.black.withAlphaComponent(0.5)
         
         label.text = text
-        label.textColor = UIColor.whiteColor()
-        label.textAlignment = NSTextAlignment.Center
-        label.font = UIFont.boldSystemFontOfSize(14)
+        label.textColor = UIColor.white
+        label.textAlignment = NSTextAlignment.center
+        label.font = UIFont.boldSystemFont(ofSize: 14)
         
         label.layer.cornerRadius = 2
         label.clipsToBounds = true
@@ -111,9 +111,9 @@ class ViewController: UIViewController {
     private func generateRandomData(numberOfItems: Int, max: Double) -> [Double] {
         var data = [Double]()
         for _ in 0 ..< numberOfItems {
-            var randomNumber = Double(random()) % max
+            var randomNumber = Double(arc4random()).truncatingRemainder(dividingBy: max)
             
-            if(random() % 100 < 10) {
+            if(arc4random() % 100 < 10) {
                 randomNumber *= 3
             }
             
@@ -122,7 +122,7 @@ class ViewController: UIViewController {
         return data
     }
     
-    private func generateSequentialLabels(numberOfItems: Int, text: String) -> [String] {
+    private func generateSequentialLabels(_ numberOfItems: Int, text: String) -> [String] {
         var labels = [String]()
         for i in 0 ..< numberOfItems {
             labels.append("\(text) \(i+1)")
@@ -132,40 +132,40 @@ class ViewController: UIViewController {
     
     // The type of the current graph we are showing.
     enum GraphType {
-        case Dark
-        case Bar
-        case Dot
-        case Pink
+        case dark
+        case bar
+        case dot
+        case pink
         
         mutating func next() {
             switch(self) {
-            case .Dark:
-                self = GraphType.Bar
-            case .Bar:
-                self = GraphType.Dot
-            case .Dot:
-                self = GraphType.Pink
-            case .Pink:
-                self = GraphType.Dark
+            case .dark:
+                self = GraphType.bar
+            case .bar:
+                self = GraphType.dot
+            case .dot:
+                self = GraphType.pink
+            case .pink:
+                self = GraphType.dark
             }
         }
         
         func description() -> String {
             switch(self) {
-            case .Dark:
+            case .dark:
                 return "Dark"
-            case .Bar:
+            case .bar:
                 return "Bar"
-            case .Dot:
+            case .dot:
                 return "Dot"
-            case .Pink:
+            case .pink:
                 return "Pink"
             }
 
         }
     }
     
-    override func prefersStatusBarHidden() -> Bool {
+    override var prefersStatusBarHidden : Bool {
         return true
     }
 }


### PR DESCRIPTION
- Swift 3 migration of the ScrollableGraphView component including both Sample applications.
- this version also includes the renamed methods and enums conforming to the new Swift 3 naming conventions from Apple. 
- instead of the other existing pull request this one handles Ranges correctly and therefore all datapoints are drawn as before (not only the initial ones), this doesn't work using the other PR (also see my comment there)