### PR TITLE
Fixed x-axis labels duplication

### DIFF
--- a/Classes/ScrollableGraphView.swift
+++ b/Classes/ScrollableGraphView.swift
@@ -1003,6 +1003,8 @@ import UIKit
             
             label.frame = CGRect(origin: CGPoint(x: position.x - label.frame.width / 2, y: position.y + dataPointLabelTopMargin), size: label.frame.size)
             
+            let _ = labelsView.subviews.filter { $0.frame == label.frame }.map { $0.removeFromSuperview() }
+
             labelsView.addSubview(label)
         }
     }


### PR DESCRIPTION
While swiping graph view x-axis label duplicating after redraw. This
commit fixed it.